### PR TITLE
rockchip: tinker: set ethaddr in late init

### DIFF
--- a/board/rockchip/tinker_rk3288/tinker-rk3288.c
+++ b/board/rockchip/tinker_rk3288/tinker-rk3288.c
@@ -5,3 +5,29 @@
  */
 
 #include <common.h>
+#include <i2c.h>
+#include <netdev.h>
+
+int rk_board_late_init(void)
+{
+	struct udevice *dev;
+	int ret;
+	u8 mac[6];
+
+	ret = i2c_get_chip_for_busnum(2, 0x50, 1, &dev);
+	if (ret) {
+		debug("failed to get eeprom\n");
+		return 0;
+	}
+
+	ret = dm_i2c_read(dev, 0x0, mac, 6);
+	if (ret) {
+		debug("failed to read mac\n");
+		return 0;
+	}
+
+	if (is_valid_ethaddr(mac))
+		eth_setenv_enetaddr("ethaddr", mac);
+
+	return 0;
+}


### PR DESCRIPTION
This PR sets ethernet mac address in late init for Tinker Board and prevents getting a random mac address at each boot.
Address is loaded from eeprom same as in `/etc/init.d/rockchip.sh` on Tinker OS, first 6 bytes from 0x50 on i2c2.

Tested with my experimental LibreELEC Tinker Board project at https://github.com/Kwiboo/LibreELEC.tv/tree/tinkerboard/projects/TinkerBoard