### PR TITLE
Fix 24bpp logo bmp display problem

### DIFF
--- a/common/lcd.c
+++ b/common/lcd.c
@@ -711,7 +711,7 @@ int lcd_display_bitmap(ulong bmp_image, int x, int y)
 				*(fb++) = *(bmap++);
 				*(fb++) = *(bmap++);
 				*(fb++) = *(bmap++);
-				*(fb++) = 0;
+				*(fb++) = (uchar)255;
 			}
 			fb -= lcd_line_length + width * (bpix / 8);
 		}


### PR DESCRIPTION
If set the alpha channel value to 0 for 24bpp bmp logo file, the logo will not display
on the screen. Just set it to 255 which is the max value of alpha channel of RGBA
color space, and the bmp logo will display correctly.