### PR TITLE
rk3399: emmc: fix sdhci frequency set issue.

### DIFF
--- a/arch/arm/dts/rk3399.dtsi
+++ b/arch/arm/dts/rk3399.dtsi
@@ -306,7 +306,6 @@
 		arasan,soc-ctl-syscon = <&grf>;
 		assigned-clocks = <&cru SCLK_EMMC>;
 		assigned-clock-rates = <200000000>;
-		max-frequency = <150000000>;
 		clocks = <&cru SCLK_EMMC>, <&cru ACLK_EMMC>;
 		clock-names = "clk_xin", "clk_ahb";
 		clock-output-names = "emmc_cardclock";


### PR DESCRIPTION
if emmc error, load kernel error
error log:
        Hit any key to stop autoboot:  0
        rkparm_init_param param read fail
        android_bootloader_boot_flow Could not find misc partition
        rkparm_init_param param read fail
        get part misc fail -1
        ANDROID: reboot reason: "(none)"
        rkparm_init_param param read fail
        android_bootloader_boot_flow Could not found bootable partition boot
        Android boot failed, error -1.