### PR TITLE
Set right offset for dtb file

### DIFF
--- a/arch/arm/mach-rockchip/resource_img.c
+++ b/arch/arm/mach-rockchip/resource_img.c
@@ -459,7 +459,7 @@ parse_second_pos_dtb:
 		entry->f_size = fdt_totalsize((void *)hdr);
 		entry->f_offset = 0;
 
-		add_file_to_list(entry, part_info.start);
+		add_file_to_list(entry, rsce_base);
 		free(entry);
 		ret = 0;
 		printf("Found DTB in %s part(second pos)\n", boot_partname);

--- a/arch/arm/mach-rockchip/resource_img.c
+++ b/arch/arm/mach-rockchip/resource_img.c
@@ -458,6 +458,7 @@ parse_second_pos_dtb:
 		memcpy(entry->name, DTB_FILE, sizeof(DTB_FILE));
 		entry->f_size = fdt_totalsize((void *)hdr);
 		entry->f_offset = 0;
+		entry->hash_size = 0;
 
 		add_file_to_list(entry, rsce_base);
 		free(entry);


### PR DESCRIPTION
Set right offset for dtb file if read from second pos in android recovery image.
The right offset is used to locate the file in the recovery image and the header gets checked correctly but when added to the file list the wrong base address is used.
The file points to the image header not to the dtb on later usage.