### PR TITLE
pinctrl: fixed compile error caused by potentially uninitialized data pointer

### DIFF
--- a/drivers/pinctrl/pinctrl-rockchip.c
+++ b/drivers/pinctrl/pinctrl-rockchip.c
@@ -829,7 +829,7 @@ static void rockchip_get_recalced_mux(struct rockchip_pin_bank *bank, int pin,
 {
 	struct rockchip_pinctrl_priv *priv = bank->priv;
 	struct rockchip_pin_ctrl *ctrl = priv->ctrl;
-	struct rockchip_mux_recalced_data *data;
+	struct rockchip_mux_recalced_data *data = NULL;
 	int i;
 
 	for (i = 0; i < ctrl->niomux_recalced; i++) {
@@ -840,6 +840,9 @@ static void rockchip_get_recalced_mux(struct rockchip_pin_bank *bank, int pin,
 	}
 
 	if (i >= ctrl->niomux_recalced)
+		return;
+
+	if (data == NULL)
 		return;
 
 	*reg = data->reg;
@@ -1561,7 +1564,7 @@ rockchip_get_mux_route(struct rockchip_pin_bank *bank, int pin,
 {
 	struct rockchip_pinctrl_priv *priv = bank->priv;
 	struct rockchip_pin_ctrl *ctrl = priv->ctrl;
-	struct rockchip_mux_route_data *data;
+	struct rockchip_mux_route_data *data = NULL;
 	int i;
 
 	for (i = 0; i < ctrl->niomux_routes; i++) {
@@ -1573,6 +1576,10 @@ rockchip_get_mux_route(struct rockchip_pin_bank *bank, int pin,
 
 	if (i >= ctrl->niomux_routes)
 		return ROUTE_TYPE_INVALID;
+
+	if (data == NULL)
+		return ROUTE_TYPE_INVALID;
+	
 
 	*reg = data->route_offset;
 	*value = data->route_val;

--- a/drivers/pinctrl/rockchip/pinctrl-rockchip-core.c
+++ b/drivers/pinctrl/rockchip/pinctrl-rockchip-core.c
@@ -42,7 +42,7 @@ void rockchip_get_recalced_mux(struct rockchip_pin_bank *bank, int pin,
 {
 	struct rockchip_pinctrl_priv *priv = bank->priv;
 	struct rockchip_pin_ctrl *ctrl = priv->ctrl;
-	struct rockchip_mux_recalced_data *data;
+	struct rockchip_mux_recalced_data *data = NULL;
 	int i;
 
 	for (i = 0; i < ctrl->niomux_recalced; i++) {
@@ -53,6 +53,9 @@ void rockchip_get_recalced_mux(struct rockchip_pin_bank *bank, int pin,
 	}
 
 	if (i >= ctrl->niomux_recalced)
+		return;
+
+	if (data == NULL)
 		return;
 
 	*reg = data->reg;
@@ -66,7 +69,7 @@ rockchip_get_mux_route(struct rockchip_pin_bank *bank, int pin,
 {
 	struct rockchip_pinctrl_priv *priv = bank->priv;
 	struct rockchip_pin_ctrl *ctrl = priv->ctrl;
-	struct rockchip_mux_route_data *data;
+	struct rockchip_mux_route_data *data = NULL;
 	int i;
 
 	for (i = 0; i < ctrl->niomux_routes; i++) {
@@ -77,6 +80,9 @@ rockchip_get_mux_route(struct rockchip_pin_bank *bank, int pin,
 	}
 
 	if (i >= ctrl->niomux_routes)
+		return ROUTE_TYPE_INVALID;
+
+	if (data == NULL)
 		return ROUTE_TYPE_INVALID;
 
 	*reg = data->route_offset;


### PR DESCRIPTION
This fixes the gcc "maybe-uninitialized" error, the `data` pointer is set to NULL by default and checked if it still is NULL after an assignment should have happened.

Build successfully using gcc in version 12.4.0 and successfully boots on my rv1106g3 chip.