### PR TITLE
video/drm: bmp_helper: fix out-of-bounds write in RLE8 DELTA decoder

### DIFF
--- a/drivers/video/drm/bmp_helper.c
+++ b/drivers/video/drm/bmp_helper.c
@@ -77,6 +77,8 @@ static void decode_rle8_bitmap(void *psrc, void *pdst, uint16_t *cmap,
 				} else {
 					y++;
 				}
+				if (y < 0 || y >= height)
+					decode = 0;
 				break;
 			case BMP_RLE8_EOBMP:
 				/* end of bitmap */
@@ -95,12 +97,14 @@ static void decode_rle8_bitmap(void *psrc, void *pdst, uint16_t *cmap,
 					dst += bmap[2] * 2;
 				}
 				bmap += 4;
+				if (x >= width || y < 0 || y >= height)
+					decode = 0;
 				break;
 			default:
 				/* unencoded run */
 				runlen = bmap[1];
 				bmap += 2;
-				if (y >= height || x >= width) {
+				if (y < 0 || y >= height || x >= width) {
 					decode = 0;
 					break;
 				}
@@ -117,7 +121,7 @@ static void decode_rle8_bitmap(void *psrc, void *pdst, uint16_t *cmap,
 			}
 		} else {
 			/* encoded run */
-			if (y < height) {
+			if (y >= 0 && y < height) {
 				runlen = bmap[0];
 				if (x < width) {
 					/* aggregate the same code */


### PR DESCRIPTION
## Summary

- Fix an out-of-bounds write vulnerability in the BMP RLE8 decoder that allows arbitrary memory writes via a crafted BMP file
- The [DELTA escape handler](https://github.com/rockchip-linux/u-boot/blob/next-dev/drivers/video/drm/bmp_helper.c#L85-L98) in [`decode_rle8_bitmap()`](https://github.com/rockchip-linux/u-boot/blob/next-dev/drivers/video/drm/bmp_helper.c#L51-L142) adjusts the destination pointer without bounds checking, and the [EOL handler](https://github.com/rockchip-linux/u-boot/blob/next-dev/drivers/video/drm/bmp_helper.c#L70-L80) has the same class of bug
- Both the [encoded run](https://github.com/rockchip-linux/u-boot/blob/next-dev/drivers/video/drm/bmp_helper.c#L120) and [unencoded run](https://github.com/rockchip-linux/u-boot/blob/next-dev/drivers/video/drm/bmp_helper.c#L103) paths fail to reject negative `y` values produced by these escapes

## Detail

The RLE8 DELTA escape (`0x00 0x02 dx dy`) in [`drivers/video/drm/bmp_helper.c`](https://github.com/rockchip-linux/u-boot/blob/next-dev/drivers/video/drm/bmp_helper.c) [subtracts `dy` from `y`](https://github.com/rockchip-linux/u-boot/blob/next-dev/drivers/video/drm/bmp_helper.c#L89) in flip mode with no validation. A single DELTA byte can drive `y` negative, moving `dst` backwards past the decode buffer. The existing bounds checks on [encoded runs (`y < height`)](https://github.com/rockchip-linux/u-boot/blob/next-dev/drivers/video/drm/bmp_helper.c#L120) and [unencoded runs (`y >= height`)](https://github.com/rockchip-linux/u-boot/blob/next-dev/drivers/video/drm/bmp_helper.c#L103) both pass for negative `y` because the comparisons are signed, so the decoder continues writing attacker-controlled 16-bit [colour table values](https://github.com/rockchip-linux/u-boot/blob/next-dev/drivers/video/drm/bmp_helper.c#L177-L183) into memory before the buffer.

This patch adds bounds checks to the DELTA and EOL handlers, recomputes `dst` from the base pointer `pdst` in both cases to prevent accumulated drift, and adds lower-bound checks for `y` on both run-type code paths.